### PR TITLE
Add new example of cloud command receiver

### DIFF
--- a/cloud-command-receiver/Dockerfile
+++ b/cloud-command-receiver/Dockerfile
@@ -1,0 +1,39 @@
+FROM ubuntu:latest
+
+# The LiveEdge Compute environment requires these user groups and permissions
+# in order to allow access to certain outside servers. 
+# These two lines *MUST* be included in your Dockerfile
+RUN groupadd -g 3003 aid_inet && usermod -G nogroup -g aid_inet _apt
+RUN groupadd -g 3004 net_raw && usermod -G net_raw root
+
+# First, set up the main directory structure
+RUN mkdir /cloud-reciever
+COPY . /cloud-reciever
+WORKDIR /cloud-reciever
+RUN rm -rf node_modules
+
+# Need to install SSH first
+RUN apt-get update
+
+# Ubuntu may prompt for input if these values aren't set, slowing the build process.
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ=America/Denver
+
+# Running this separately to handle an input issue when installing tzdata
+RUN apt-get install -y tzdata
+
+# This environment variable is used by our Node script to determine the port our server runs on
+ENV LISTENING_PORT=8882
+
+# There is no platform independent way to easily get the host address to access the LiveEdge Compute API.
+# However, this is the default used by Docker in Linux, so we'll set it here. 
+ENV HOST_IP_ADDRESS="172.17.0.1"
+
+# Our application requires these two programs to run
+RUN apt-get install -y npm nodejs
+
+# Install all of our Node dependencies
+RUN npm install
+
+# When you call `docker run`, this is the command that docker will issue to start up the container.
+CMD node index.js

--- a/cloud-command-receiver/Dockerfile
+++ b/cloud-command-receiver/Dockerfile
@@ -7,9 +7,9 @@ RUN groupadd -g 3003 aid_inet && usermod -G nogroup -g aid_inet _apt
 RUN groupadd -g 3004 net_raw && usermod -G net_raw root
 
 # First, set up the main directory structure
-RUN mkdir /cloud-reciever
-COPY . /cloud-reciever
-WORKDIR /cloud-reciever
+RUN mkdir /cloud-receiver
+COPY . /cloud-receiver
+WORKDIR /cloud-receiver
 RUN rm -rf node_modules
 
 # Need to install SSH first

--- a/cloud-command-receiver/README.md
+++ b/cloud-command-receiver/README.md
@@ -1,6 +1,6 @@
-# Cloud Command Reciever
+# Cloud Command Receiver
 
-This is a brief example of a Docker container to run on an EdgeCaster and recieve commands from LiveEdge Cloud
+This is a brief example of a Docker container to run on an EdgeCaster and receive commands from LiveEdge Cloud
 
 In order to run this example, ensure that you have a Videon device enrolled in LiveEdge Cloud, updated to the latest Cloud Agent. This example also makes calls to the LiveEdge Cloud API "commands" endpoint: https://api.videoncloud.com/v1/openapi/html#operation/SendDeviceCommand
 

--- a/cloud-command-receiver/README.md
+++ b/cloud-command-receiver/README.md
@@ -2,7 +2,7 @@
 
 This is a brief example of a Docker container to run on an EdgeCaster and recieve commands from LiveEdge Cloud
 
-In order to run this example, ensure that you have a Videon device enrolled in LiveEdge Cloud. This example also makes calls to the LiveEdge Cloud API "commands" endpoint: https://api.videoncloud.com/v1/openapi/html#operation/SendDeviceCommand
+In order to run this example, ensure that you have a Videon device enrolled in LiveEdge Cloud, updated to the latest Cloud Agent. This example also makes calls to the LiveEdge Cloud API "commands" endpoint: https://api.videoncloud.com/v1/openapi/html#operation/SendDeviceCommand
 
 Additionally, you will need to generate a Personal Access Token (PAT) in LiveEdge Cloud, under "Access Tokens": https://videoncloud.com/account
 
@@ -46,7 +46,7 @@ Upon a successful build, run the container in the background to see it in action
 [LiveEdge Compute Shell]: docker run -p8882:8882 --name cloud-receiver cloud-command-receiver &
 ```
 
-### Running the Example Tests
+# Running the Example Tests
 
 To run the tests, you will send API calls to LiveEdge Cloud, manually entering information into the bracketed ('{...}') spaces of user information.
 
@@ -62,7 +62,7 @@ curl -H "Authorization: PAT {YOUR_PAT}" https://api.videoncloud.com/v1/devices?o
 
 Copy the GUID of your device, then
 
-#### Get "Messages" Stored in Docker Container
+## Get "Messages" Stored in Docker Container
 
 ```
 curl -X POST -d '{ "command": "rest_direct_get", "rest_endpoint": ":8882/cloud-command"}' -H "Authorization: PAT {YOUR_PAT}" https://api.videoncloud.com/v1/devices/{YOUR_DEVICE_GUID}/commands
@@ -87,7 +87,7 @@ This should then return information from LiveEdge Cloud that contains the list o
 }
 ```
 
-#### Post a new "Message" to Docker Container
+## Post a new "Message" to Docker Container
 
 ```
 curl -X POST -d '{ "command": "rest_direct_post", "rest_endpoint": ":8882/cloud-command"}' -H "Authorization: PAT {YOUR_PAT}" https://api.videoncloud.com/v1/devices/{YOUR_DEVICE_GUID}/commands
@@ -108,7 +108,7 @@ This should then return information from LiveEdge Cloud that contains the list o
 }
 ```
 
-#### Put a new "Message" to message in Docker Container
+## Put a new "Message" to message in Docker Container
 
 ```
 curl -X POST -d '{ "command": "rest_direct_put", "rest_endpoint": ":8882/cloud-command", "data": {"id":1, "message":"First EDITED message"}}' -H "Authorization: PAT {YOUR_PAT}" https://api.videoncloud.com/v1/devices/{YOUR_DEVICE_GUID}/commands
@@ -129,7 +129,7 @@ This should then return information from LiveEdge Cloud that contains the list o
 }
 ```
 
-#### Delete a "Message" in Docker Container
+## Delete a "Message" in Docker Container
 
 ```
 curl -X POST -d '{ "command": "rest_direct_delete", "rest_endpoint": ":8882/cloud-command/1" }' -H "Authorization: PAT {YOUR_PAT}" https://api.videoncloud.com/v1/devices/{YOUR_DEVICE_GUID}/commands

--- a/cloud-command-receiver/README.md
+++ b/cloud-command-receiver/README.md
@@ -1,0 +1,148 @@
+# Cloud Command Reciever
+
+This is a brief example of a Docker container to run on an EdgeCaster and recieve commands from LiveEdge Cloud
+
+In order to run this example, ensure that you have a Videon device enrolled in LiveEdge Cloud. This example also makes calls to the LiveEdge Cloud API "commands" endpoint: https://api.videoncloud.com/v1/openapi/html#operation/SendDeviceCommand
+
+Additionally, you will need to generate a Personal Access Token (PAT) in LiveEdge Cloud, under "Access Tokens": https://videoncloud.com/account
+
+# Running the Example Docker Container
+
+To run this example on your local device, you'll first need to [set up your development environment](https://support.videonlabs.com/hc/en-us/articles/4403731257491-Getting-Started-with-the-LiveEdge-Compute-Toolkit) and be able to access the devuice shell through `adb`:
+
+```
+[Local Machine]: adb connect <device ip>
+[Local Machine]: adb root
+[Local Machine]: adb shell
+```
+
+Once logged into the device's shell, you must set up the local environment with the `source` command:
+
+```
+[LiveEdge Compute Shell]: source /data/local/vstream/etc/env.sh
+```
+
+Create a working directory in `/data/local/`:
+
+```
+[LiveEdge Compute Shell]: mkdir /data/local/cloud-command-receiver
+```
+
+Clone this repository to a directory on your local machine, then use `adb` to copy the files to the working directory you created on the device:
+
+```
+[Local Machine]: adb push . /data/local/cloud-command-receiver
+```
+
+Run the `docker build` command in the working directory:
+
+```
+[LiveEdge Compute Shell]: docker build -t cloud-command-receiver .
+```
+
+Upon a successful build, run the container in the background to see it in action:
+
+```
+[LiveEdge Compute Shell]: docker run -p8882:8882 --name cloud-receiver cloud-command-receiver &
+```
+
+### Running the Example Tests
+
+To run the tests, you will send API calls to LiveEdge Cloud, manually entering information into the bracketed ('{...}') spaces of user information.
+
+```
+curl -H "Authorization: PAT {YOUR_PAT}" https://api.videoncloud.com/v1/orgs
+
+```
+Copy the GUID of the org your device is enrolled in, then
+
+```
+curl -H "Authorization: PAT {YOUR_PAT}" https://api.videoncloud.com/v1/devices?org_guid={YOUR_ORG_GUID}
+```
+
+Copy the GUID of your device, then
+
+#### Get "Messages" Stored in Docker Container
+
+```
+curl -X POST -d '{ "command": "rest_direct_get", "rest_endpoint": ":8882/cloud-command"}' -H "Authorization: PAT {YOUR_PAT}" https://api.videoncloud.com/v1/devices/{YOUR_DEVICE_GUID}/commands
+```
+
+Copy the command GUID that is returned, then
+
+```
+curl -H "Authorization: PAT {YOUR_PAT}" https://api.videoncloud.com/v1/devices/{YOUR_DEVICE_GUID}/commands/{COMMAND_GUID}
+```
+
+This should then return information from LiveEdge Cloud that contains the list of "Message" objects stored by the Docker container as the value for the "data" field:
+
+```
+"data": { 
+    "messages": [
+        {
+            "id": 1, 
+            "message": "First message"
+        }
+    ]
+}
+```
+
+#### Post a new "Message" to Docker Container
+
+```
+curl -X POST -d '{ "command": "rest_direct_post", "rest_endpoint": ":8882/cloud-command"}' -H "Authorization: PAT {YOUR_PAT}" https://api.videoncloud.com/v1/devices/{YOUR_DEVICE_GUID}/commands
+```
+
+Copy the command GUID that is returned, then
+
+```
+curl -H "Authorization: PAT {YOUR_PAT}" https://api.videoncloud.com/v1/devices/{YOUR_DEVICE_GUID}/commands/{COMMAND_GUID}
+```
+
+This should then return information from LiveEdge Cloud that contains the list of "Message" objects stored by the Docker container as the value for the "data" field:
+
+```
+"data": { 
+    "id": 2, 
+    "message": "(New) Message #2"
+}
+```
+
+#### Put a new "Message" to message in Docker Container
+
+```
+curl -X POST -d '{ "command": "rest_direct_put", "rest_endpoint": ":8882/cloud-command", "data": {"id":1, "message":"First EDITED message"}}' -H "Authorization: PAT {YOUR_PAT}" https://api.videoncloud.com/v1/devices/{YOUR_DEVICE_GUID}/commands
+```
+
+Copy the command GUID that is returned, then
+
+```
+curl -H "Authorization: PAT {YOUR_PAT}" https://api.videoncloud.com/v1/devices/{YOUR_DEVICE_GUID}/commands/{COMMAND_GUID}
+```
+
+This should then return information from LiveEdge Cloud that contains the list of "Message" objects stored by the Docker container as the value for the "data" field:
+
+```
+"data": {
+    "id": 1,
+    "message": "First EDITED message"
+}
+```
+
+#### Delete a "Message" in Docker Container (Not available in this example yet)
+
+```
+curl -X POST -d '{ "command": "rest_direct_delete", "rest_endpoint": ":8882/cloud-command/1" }' -H "Authorization: PAT {YOUR_PAT}" https://api.videoncloud.com/v1/devices/{YOUR_DEVICE_GUID}/commands
+```
+
+Copy the command GUID that is returned, then
+
+```
+curl -H "Authorization: PAT {YOUR_PAT}" https://api.videoncloud.com/v1/devices/{YOUR_DEVICE_GUID}/commands/{COMMAND_GUID}
+```
+
+This should then return information from LiveEdge Cloud that contains the list of "Message" objects stored by the Docker container as the value for the "data" field:
+
+```
+
+```

--- a/cloud-command-receiver/README.md
+++ b/cloud-command-receiver/README.md
@@ -129,7 +129,7 @@ This should then return information from LiveEdge Cloud that contains the list o
 }
 ```
 
-#### Delete a "Message" in Docker Container (Not available in this example yet)
+#### Delete a "Message" in Docker Container
 
 ```
 curl -X POST -d '{ "command": "rest_direct_delete", "rest_endpoint": ":8882/cloud-command/1" }' -H "Authorization: PAT {YOUR_PAT}" https://api.videoncloud.com/v1/devices/{YOUR_DEVICE_GUID}/commands
@@ -144,5 +144,5 @@ curl -H "Authorization: PAT {YOUR_PAT}" https://api.videoncloud.com/v1/devices/{
 This should then return information from LiveEdge Cloud that contains the list of "Message" objects stored by the Docker container as the value for the "data" field:
 
 ```
-
+"Message with id of 1 deleted"
 ```

--- a/cloud-command-receiver/index.js
+++ b/cloud-command-receiver/index.js
@@ -1,0 +1,74 @@
+//We use these to serve our app and access the local API, respectively
+var restify = require('restify');
+var axios = require('axios');
+
+var app = restify.createServer();
+
+app.use(restify.plugins.bodyParser());
+app.use(restify.plugins.queryParser());
+
+const LISTENING_PORT = process.env.LISTENING_PORT;
+
+var videon_ip = process.env.HOST_IP_ADDRESS;
+
+// Sample list of objects
+let messages = [
+    { "id": 1, "message": 'First message' }
+  ];
+
+//This endpoint will respond with all messages stored in the container
+app.get('/cloud-command', function(req, res, next) {
+    res.send(200, { messages });
+    next();
+    return;
+});
+
+//This endpoint will create our example object and store the included information, returning that information
+app.post('/cloud-command', function(req, res, next) {
+    let id = messages[messages.length - 1].id + 1;
+    let newMessage = { "id": id, "message": '(New) Message #' + id };
+    messages.push(newMessage);
+    res.send(200, newMessage);
+    next();
+    return;
+});
+
+//This endpoint will update the specified message with a new message and return that updated message
+app.put('/cloud-command', function(req, res, next) {
+    let id = req.body.id;
+    let updatedMessage = req.body.message; // Assuming the request body contains the updated message data
+
+    // Find the message with the specified ID
+    let index = messages.findIndex(message => message.id === id);
+
+    if (index !== -1) {
+        // Update the message with the new data
+        messages[index].message = updatedMessage;
+        res.send(200, messages[index]);
+    } else {
+        res.send(500, "Id #" + id + " not found \n" + JSON.stringify(req.body));
+    }
+    next();
+    return;
+});
+
+// This endpoint will simply respond with a static message to confirm this the message was deleted
+app.del('/cloud-command/:id', function(req, res, next) {
+    let id = req.params.id.toString();
+    // Find the message with the specified ID
+    let index = messages.findIndex(message => message.id.toString() === id);
+
+    if (index !== -1) {
+        // Update the message with the new data
+        messages.splice(index, 1);
+        res.send(200, "Message with id of " + id + " deleted");
+    } else {
+        res.send(500, "Id #" + id + " not found. Index = " + index);
+    }
+    next();
+    return;
+});
+
+app.listen(LISTENING_PORT, function() {
+    console.log("Listening on port " + LISTENING_PORT);
+});

--- a/cloud-command-receiver/index.js
+++ b/cloud-command-receiver/index.js
@@ -46,7 +46,7 @@ app.put('/cloud-command', function(req, res, next) {
         messages[index].message = updatedMessage;
         res.send(200, messages[index]);
     } else {
-        res.send(500, "Id #" + id + " not found \n" + JSON.stringify(req.body));
+        res.send(500, "Id #" + id + " not found");
     }
     next();
     return;
@@ -63,7 +63,7 @@ app.del('/cloud-command/:id', function(req, res, next) {
         messages.splice(index, 1);
         res.send(200, "Message with id of " + id + " deleted");
     } else {
-        res.send(500, "Id #" + id + " not found. Index = " + index);
+        res.send(500, "Id #" + id + " not found");
     }
     next();
     return;

--- a/cloud-command-receiver/package.json
+++ b/cloud-command-receiver/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "axios": "^0.23.0",
+    "restify": "^8.6.0"
+  }
+}


### PR DESCRIPTION
This example will be able to receive the new rest_direct commands from the LiveEdge Cloud API, allowing for easier demonstration of the feature.